### PR TITLE
Implement customizable QoS for MQTT subscriber

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,7 @@
 * **Failover 지원**: 지수 백오프 기반 자동 재연결 및 토픽 재구독
 * **JSON 필드 추출**: 경량 경로 파서를 사용하는 `PathFilterBuilder`로 손쉬운 값 조회
 * **임시 메시지 버퍼**: MQTT로 수신한 메시지를 버퍼에 저장(인메모리/Redis/Kafka 지원)
+* **세밀한 MQTT 설정**: 구독 QoS와 재연결 지연(initialDelay, maxDelay) 값을 직접 지정 가능
 
 ## 📦 빌드
 
@@ -73,7 +74,10 @@ dependencies {
 ```kotlin
 val manager = MqttBufferedSubscriber.builder()
     .brokerUrl("tcp://broker.hivemq.com:1883")
+    .initialDelay(1000)
+    .maxDelay(60000)
     .addTopic("sensors/data")
+    .qos(1)
     .build()
 
 manager.addListener(object : MqttBufferedSubscriber.ConnectionListener {

--- a/examples/mqtt-subscriber/src/main/kotlin/Main.kt
+++ b/examples/mqtt-subscriber/src/main/kotlin/Main.kt
@@ -5,7 +5,10 @@ import me.helloc.iot.tunnel.MqttBufferedSubscriber
 fun main() {
     val manager = MqttBufferedSubscriber.builder()
         .brokerUrl("tcp://broker.hivemq.com:1883")
+        .initialDelay(1000)
+        .maxDelay(60000)
         .addTopic("sensors/data")
+        .qos(1)
         .build()
 
     manager.addListener(DefaultConnectionListener())

--- a/examples/pipeline-demo/src/main/kotlin/Main.kt
+++ b/examples/pipeline-demo/src/main/kotlin/Main.kt
@@ -5,7 +5,10 @@ fun main() {
 
     val subscriber = MqttBufferedSubscriber.builder()
         .brokerUrl("tcp://broker.hivemq.com:1883")
+        .initialDelay(1000)
+        .maxDelay(60000)
         .addTopic("sensors/data")
+        .qos(1)
         .build()
 
     subscriber.addListener(object : MqttBufferedSubscriber.ConnectionListener, MqttBufferedSubscriber.MessageListener {

--- a/src/main/kotlin/me/helloc/iot/tunnel/MqttBufferedSubscriber.kt
+++ b/src/main/kotlin/me/helloc/iot/tunnel/MqttBufferedSubscriber.kt
@@ -166,7 +166,7 @@ class MqttBufferedSubscriber private constructor(builder: Builder) {
         fun maxDelay(delay: Long) = apply { this.maxDelay = delay }
         fun messageBuffer(buffer: MessageBuffer) = apply { this.messageBuffer = buffer }
         fun qos(qos: Int) = apply {
-            require(qos in 0..2) { "qos" }
+            require(qos in 0..2) { "QoS must be between 0 and 2" }
             this.qos = qos
         }
 

--- a/src/main/kotlin/me/helloc/iot/tunnel/MqttBufferedSubscriber.kt
+++ b/src/main/kotlin/me/helloc/iot/tunnel/MqttBufferedSubscriber.kt
@@ -48,6 +48,7 @@ class MqttBufferedSubscriber private constructor(builder: Builder) {
     private val messageListeners = CopyOnWriteArrayList<MessageListener>()
     private val initialDelay: Long = builder.initialDelay
     private val maxDelay: Long = builder.maxDelay
+    private val qos: Int = builder.qos
     @Volatile private var currentDelay: Long = initialDelay
 
     fun addListener(listener: ConnectionListener) {
@@ -101,7 +102,7 @@ class MqttBufferedSubscriber private constructor(builder: Builder) {
     private fun subscribeAll() {
         for (topic in topics) {
             try {
-                client.subscribe(topic, 1)
+                client.subscribe(topic, qos)
             } catch (_: MqttException) {
             }
         }
@@ -152,6 +153,8 @@ class MqttBufferedSubscriber private constructor(builder: Builder) {
             private set
         var messageBuffer: MessageBuffer = MessageBufferFactory.fromConfig()
             private set
+        var qos: Int = 1
+            private set
 
         fun brokerUrl(brokerUrl: String) = apply { this.brokerUrl = brokerUrl }
         fun clientId(clientId: String) = apply { this.clientId = clientId }
@@ -162,6 +165,10 @@ class MqttBufferedSubscriber private constructor(builder: Builder) {
         fun initialDelay(delay: Long) = apply { this.initialDelay = delay }
         fun maxDelay(delay: Long) = apply { this.maxDelay = delay }
         fun messageBuffer(buffer: MessageBuffer) = apply { this.messageBuffer = buffer }
+        fun qos(qos: Int) = apply {
+            require(qos in 0..2) { "qos" }
+            this.qos = qos
+        }
 
         fun build(): MqttBufferedSubscriber {
             require(!brokerUrl.isNullOrEmpty()) { "brokerUrl" }

--- a/src/test/kotlin/me/helloc/iot/tunnel/MqttBufferedSubscriberBuilderTest.kt
+++ b/src/test/kotlin/me/helloc/iot/tunnel/MqttBufferedSubscriberBuilderTest.kt
@@ -1,0 +1,48 @@
+package me.helloc.iot.tunnel
+
+import io.kotest.core.spec.style.StringSpec
+import io.kotest.assertions.throwables.shouldThrow
+import org.eclipse.paho.client.mqttv3.IMqttActionListener
+import org.eclipse.paho.client.mqttv3.IMqttToken
+import org.eclipse.paho.client.mqttv3.MqttAsyncClient
+import org.eclipse.paho.client.mqttv3.MqttConnectOptions
+import org.mockito.kotlin.argumentCaptor
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.verify
+import org.mockito.kotlin.whenever
+import java.util.concurrent.ScheduledExecutorService
+import java.util.concurrent.ScheduledFuture
+
+class MqttBufferedSubscriberBuilderTest : StringSpec({
+    "subscribes with configured qos" {
+        val client = mock<MqttAsyncClient>()
+        val scheduler = mock<ScheduledExecutorService>()
+        whenever(scheduler.schedule(org.mockito.kotlin.any<Runnable>(), org.mockito.kotlin.any(), org.mockito.kotlin.any()))
+            .thenReturn(mock<ScheduledFuture<*>>())
+
+        val manager = MqttBufferedSubscriber.builder()
+            .brokerUrl("tcp://localhost:1883")
+            .addTopic("test")
+            .clientSupplier { client }
+            .scheduler(scheduler)
+            .qos(2)
+            .build()
+
+        val captor = argumentCaptor<IMqttActionListener>()
+        whenever(client.connect(org.mockito.kotlin.any<MqttConnectOptions>(), org.mockito.kotlin.isNull(), captor.capture()))
+            .thenReturn(mock<IMqttToken>())
+
+        manager.connect()
+        captor.firstValue.onSuccess(mock())
+
+        verify(client).subscribe("test", 2)
+    }
+
+    "invalid qos throws exception" {
+        shouldThrow<IllegalArgumentException> {
+            MqttBufferedSubscriber.builder()
+                .brokerUrl("tcp://localhost:1883")
+                .qos(3)
+        }
+    }
+})

--- a/src/test/kotlin/me/helloc/iot/tunnel/MqttBufferedSubscriberTest.kt
+++ b/src/test/kotlin/me/helloc/iot/tunnel/MqttBufferedSubscriberTest.kt
@@ -27,6 +27,7 @@ class MqttBufferedSubscriberTest {
         val manager = MqttBufferedSubscriber.builder()
             .brokerUrl("tcp://localhost:1883")
             .addTopic("test")
+            .qos(1)
             .clientSupplier { client }
             .scheduler(scheduler)
             .build()
@@ -60,6 +61,7 @@ class MqttBufferedSubscriberTest {
             .scheduler(scheduler)
             .initialDelay(10)
             .maxDelay(20)
+            .qos(1)
             .build()
 
         val captor = ArgumentCaptor.forClass(IMqttActionListener::class.java)
@@ -91,6 +93,7 @@ class MqttBufferedSubscriberTest {
             .scheduler(scheduler)
             .initialDelay(10)
             .maxDelay(20)
+            .qos(2)
             .build()
         manager.addListener(listener)
 
@@ -108,7 +111,7 @@ class MqttBufferedSubscriberTest {
         connectCaptor.allValues[1].onSuccess(mock(IMqttToken::class.java))
 
         verify(scheduler).schedule(any(Runnable::class.java), eq(10L), eq(TimeUnit.MILLISECONDS))
-        verify(client, times(2)).subscribe("test", 1)
+        verify(client, times(2)).subscribe("test", 2)
         verify(listener, times(2)).onConnected()
     }
 }


### PR DESCRIPTION
## Summary
- allow configuring QoS in `MqttBufferedSubscriber.Builder`
- validate QoS values
- pass QoS when subscribing
- document new options in README and examples
- update tests and add new Kotest spec for QoS

## Testing
- `./gradlew test --no-daemon`

This closes #26

------
https://chatgpt.com/codex/tasks/task_b_685ca71dac9083309323983004acc7df